### PR TITLE
add SeaGL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2076,3 +2076,9 @@ https://blueberrymc.net
 ### Web Scrobbler
 Web Scrobbler is a browser extension created for people who listen to music online through their browser, and would like to keep an updated playback history using scrobbling services, such as Last.fm, Libre.fm and ListenBrainz.
 https://web-scrobbler.com/
+
+### SeaGL - Seattle GNU Linux Conference
+Founded in 2013, SeaGL (the Seattle GNU/Linux Conference) is a free—as in freedom and tea—grassroots technical summit dedicated to spreading awareness and knowledge about free / libre / open source software, hardware, and culture.
+
+SeaGL strives to be welcoming, enjoyable, and informative for professional technologists, newcomers, enthusiasts, and all other users of free software, regardless of their background knowledge; providing a space to bridge these experiences and strengthen the free software movement through mentorship, collaboration, and community.
+https://seagl.org/


### PR DESCRIPTION
Adding SeaGL conference organization

## Your Project ##

SeaGL - Seattle GNU Linux Conference

#### 1Password Teams URL ####

seagl.1password.com

#### Project Name ####

SeaGL

#### Short Description ####

We host the Seattle GNU Linux conference each year, either in person, hybrid or all remote.

#### Project Age ####

10 years

#### Number Of Core Contributors ####

10 

#### Project Website ####

https://seagl.org

#### Repository URL(s) ####

https://github.com/SeaGL

#### Latest Release URL(s) ####

n/a

#### License Type ####

GPL3

#### License URL ####

https://github.com/SeaGL/seagl.github.io/blob/main/LICENSE

## A Bit About Yourself  ##

I'm one of the SRE/Technology Committee chairs - I've been a volunteer member of the tech committee for the last three years, and co-chair of SeaGL 2022

#### Name ####

Don O'Neill (a.k.a. sntxrr)

#### Email ####

sntxrr@seagl.org

#### Project Role ####

I'm primarily responsible for all things tech - everything from standing up AWS resources using terraform, streaming setup, video uploads, DNS, email, Nextcloud etc.

#### Profile/Website ####

https://github.com/sntxrr
https://gitlab.com/sntxrr
https://blog.sntxrr.dev


#### Comments ####

I'm a giant fan of 1password, I would volunteer my own person 1password account, but I only have 2 license slots left.